### PR TITLE
do not add a route if there is not registered endpoint matching

### DIFF
--- a/src/TraefikKobling.Worker/Worker.cs
+++ b/src/TraefikKobling.Worker/Worker.cs
@@ -166,11 +166,10 @@ public class Worker(
                     entries[$"traefik/http/routers/{name}/entrypoints/{registeredEntryPoints++}"] = global;
             }
 
-            if (registeredEntryPoints > 0)
-            {
-                entries[$"traefik/http/routers/{name}/rule"] = router.Rule;
-                entries[$"traefik/http/routers/{name}/service"] = server.Name;
-            }
+            if (registeredEntryPoints == 0) continue;
+
+            entries[$"traefik/http/routers/{name}/rule"] = router.Rule;
+            entries[$"traefik/http/routers/{name}/service"] = server.Name;
 
             if (server.ForwardServices ?? options.ForwardServices ?? false)
             {


### PR DESCRIPTION
Current code checks if `registeredEntryPoints > 0` to decide if we should add a rule and a service record. While it most cases this means that when `registeredEntryPoints ==0` no rule gets added to the main Traefik instance, this is not entirely the case when `ForwardServices` or `ForwardMiddlewares` are enabled as the add additional records which generates an incomplete route.

This PR updates changes the behavior to skip the route altogether when no matching endpoints are found