### PR TITLE
Fixed invalid `RUN_EVERY` default value

### DIFF
--- a/src/TraefikKobling.Worker/Configuration/KoblingOptions.cs
+++ b/src/TraefikKobling.Worker/Configuration/KoblingOptions.cs
@@ -3,7 +3,7 @@ namespace TraefikKobling.Worker.Configuration;
 public class KoblingOptions
 {
     public required Server[] Servers { get; set; }
-    public int? RunEvery { get; set; }
+    public int RunEvery { get; set; }
     public bool? ForwardMiddlewares { get; set; }
     public bool? ForwardServices { get; set; }
 }

--- a/src/TraefikKobling.Worker/Extensions/ConfigurationExtensions.cs
+++ b/src/TraefikKobling.Worker/Extensions/ConfigurationExtensions.cs
@@ -28,7 +28,7 @@ public static class ConfigurationExtensions
         var options = new KoblingOptions
         {
             Servers = servers.ToArray(),
-            RunEvery = configuration.GetValue<int>("RUN_EVERY"),
+            RunEvery = configuration.GetValue("RUN_EVERY",60),
             ForwardMiddlewares = configuration.GetValue<bool?>(nameof(KoblingOptions.ForwardMiddlewares)),
             ForwardServices = configuration.GetValue<bool?>(nameof(KoblingOptions.ForwardMiddlewares))
         };

--- a/src/TraefikKobling.Worker/Worker.cs
+++ b/src/TraefikKobling.Worker/Worker.cs
@@ -15,9 +15,9 @@ public class Worker(
     : BackgroundService
 {
     private readonly Server[] _servers = options.Servers;
-    private readonly int _runEvery = options.RunEvery ?? 60;
+    private readonly int _runEvery = options.RunEvery;
 
-    private readonly IDictionary<string,string> _oldEntries = new Dictionary<string, string>();
+    private readonly Dictionary<string,string> _oldEntries = new();
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {


### PR DESCRIPTION
When reading the environment variable `RUN_EVERY`, It was reading an `int` type instead of `int?`. So instead of defaulting to `null` and having the value overridden in the worker service, the value would be `0` and it would never be overridden by the default value of `60`.

This PR moves the default value to the options configuration instead.